### PR TITLE
Keep alive while timer runs

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -38,14 +38,11 @@ public class Timer.Application : Gtk.Application {
     }
 
     protected override void activate () {
-        warning (">>>> Application.activate...");
         if (get_windows ().length () > 0) {
-            warning (">>>> Application.data");
             get_windows ().data.present ();
             return;
         }
 
-        warning (">>>> Application.main_window.construct");
         main_window = new MainWindow (this) {
             title = "Time Limit"
         };

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -21,8 +21,9 @@
 
 public class Timer.MainWindow : Hdy.ApplicationWindow {
 
-    public signal void send_notification (Notification notification);
+    public signal void schedule_notification (GLib.DateTime? datetime);
     private uint configure_id;
+    private Timer.Widgets.Clock clock;
 
     public MainWindow (Gtk.Application application) {
         Object (
@@ -51,7 +52,7 @@ public class Timer.MainWindow : Hdy.ApplicationWindow {
 
         header.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
-        var clock = new Timer.Widgets.Clock (header);
+        clock = new Timer.Widgets.Clock (header);
         add (clock);
 
         key_release_event.connect ((event) => {
@@ -94,5 +95,18 @@ public class Timer.MainWindow : Hdy.ApplicationWindow {
         });
 
         return base.configure_event (event);
+    }
+
+    public void set_scheduled_notification_datetime (GLib.DateTime? datetime) {
+        if (datetime == null) {
+            clock.seconds = 0;
+
+        } else {
+            var now = new GLib.DateTime.now_local ();
+            clock.seconds = datetime.difference (now) / 1000000;
+
+            clock.pause = false;
+            clock.start_ticking ();
+        }
     }
 }

--- a/src/Widgets/Clock.vala
+++ b/src/Widgets/Clock.vala
@@ -175,12 +175,6 @@ public class Timer.Widgets.Clock : Gtk.Overlay {
         update_labels ();
 
         if (seconds <= 0) {
-            var main_window = (Timer.MainWindow) parent.parent;
-            var notification = new Notification (_("It's time!"));
-            notification.set_body (_("Your time limit is over."));
-            notification.set_priority (NotificationPriority.URGENT);
-            main_window.send_notification (notification);
-
             Granite.Services.Application.set_progress_visible.begin (false);
         }
     }
@@ -196,13 +190,16 @@ public class Timer.Widgets.Clock : Gtk.Overlay {
     }
 
     private void on_pause_changed () {
+        var main_window = (Timer.MainWindow) parent.parent;
+
         if (!button_press_active && !pause && seconds > 0) {
-            Timeout.add_seconds (1, () => {
-                if (!pause) {
-                    seconds = GLib.Math.fmax(0, seconds - 1);
-                }
-                return !pause && seconds > 0;
-            });
+            start_ticking ();
+
+            var notification_datetime = new GLib.DateTime.now_local ();
+            main_window.schedule_notification (notification_datetime.add_seconds (seconds));
+
+        } else {
+            main_window.schedule_notification (null);
         }
         update_labels ();
     }
@@ -295,5 +292,14 @@ public class Timer.Widgets.Clock : Gtk.Overlay {
             }
         }
         return progress;
+    }
+
+    public void start_ticking () {
+        Timeout.add_seconds (1, () => {
+            if (!pause) {
+                seconds = GLib.Math.fmax(0, seconds - 1);
+            }
+            return !pause && seconds > 0;
+        });
     }
 }


### PR DESCRIPTION
This PR fixes #31 by keeping the application alive in the background as long as a timer is running. This also guarantees the notification to be shown once the time is up. Supersedes the daemon approach in #51 since this is far easier AND compatible with Flatpak.

Important sidenote: This does not keep timers running in case you are logging out or reboot.