### PR TITLE
ProgressBar: Fix deprecations

### DIFF
--- a/src/Widgets/ProgressBar.vala
+++ b/src/Widgets/ProgressBar.vala
@@ -35,7 +35,7 @@ public class Timer.Widgets.ProgressBar : Gtk.DrawingArea {
             int width = get_allocated_width ();
             int height = get_allocated_height ();
 
-            radius = (width - margin_left - margin_right) / 2;
+            radius = (width - margin_start - margin_end) / 2;
 
             center = Gdk.Point () {
                 x = width / 2,


### PR DESCRIPTION
Fix the following warnings on build:

```
../src/Widgets/ProgressBar.vala:38.31-38.41: warning: `Gtk.Widget.margin_left' has been deprecated since 3.12
../src/Widgets/ProgressBar.vala:38.45-38.56: warning: `Gtk.Widget.margin_right' has been deprecated since 3.12
Compilation succeeded - 2 warning(s)
```
